### PR TITLE
Grant release workflow write permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,6 +35,8 @@ jobs:
           version: ${{ inputs.version || null }}
 
       - name: Create a GitHub release
+        permissions:
+          contents: write
         uses: ncipollo/release-action@v1
         with:
           commit: ${{ inputs.ref || github.sha }}


### PR DESCRIPTION
To create a GitHub release and git tag, the workflow must have permission to write contents to the repository. This grant should resolve [the current error](https://github.com/lamarmeigs/terraform-aws-pipenv-lambdas/actions/runs/8739828042).