### PR TITLE
Specify permissions on job, not step

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,6 +23,8 @@ jobs:
   release:
     if: github.repository == 'lamarmeigs/terraform-aws-pipenv-lambdas'
     name: 'Release'
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -35,8 +37,6 @@ jobs:
           version: ${{ inputs.version || null }}
 
       - name: Create a GitHub release
-        permissions:
-          contents: write
         uses: ncipollo/release-action@v1
         with:
           commit: ${{ inputs.ref || github.sha }}


### PR DESCRIPTION
What it says on the tin. This matches [example usage](https://github.com/ncipollo/release-action?tab=readme-ov-file#example) and, more importantly, [GitHub Actions syntax](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idpermissions).